### PR TITLE
Amon readme copyedit.

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,46 +8,47 @@
     Copyright (c) 2014, Joyent, Inc.
 -->
 
-# sdc-amon
+# Amon
 
-This repository is part of the Joyent SmartDataCenter project (SDC).  For
+This repository is part of the SmartDataCenter (SDC) project. For
 contribution guidelines, issues, and general documentation, visit the main
-[SDC](http://github.com/joyent/sdc) project page.
+[SDC project page](http://github.com/joyent/sdc).
 
-Amon is a monitoring and alarming system for SmartDataCenter (SDC). It has
+Amon is a monitoring and alarming system for SmartDataCenter. It has
 three components: a central master, a tree of relays, and agents.
 Probes (things to check and alarm on) and ProbeGroups (optional grouping
 of probes) are configured on the master (i.e. on the "Amon Master API" or "Amon
-API" for short). Probe data is passed from the master, via the relays to the
+API" for short). Probe data is passed from the master the relays to the
 appropriate amon-agent where the probe is run. When a probe fails/trips it
 raises an event, which passes through the relays up to the master. The
 master handles events by creating or updating alarms and sending
 notifications to the configured contacts, if appropriate (suppression and
 de-duplication rules can mean a notification is not always sent). The Amon
-Master API provides the API needed by cloudapi, and ultimately the User and
-Operations Portals, to allow management of Amon probes, probe groups and alarms.
+Master API provides the API needed by cloudapi, and ultimately the operations
+portal, to allow management of Amon probes, probe groups and alarms.
 
 
-# Design Overview
+## Design Overview
 
-There is an "Amon Master" HTTP server that runs in the "amon" core zone
-as the "amon-master" SMF service. This is the endpoint for the "Amon Master
+There is an "Amon Master" HTTP server that runs in the 'amon' core zone
+as the 'amon-master' SMF service. This is the endpoint for the "Amon Master
 API". The Amon Master stores long-lived Amon system data (probes, probe
-groups, contacts) in Moray and shorter-lived data (alarms) in redis.
-Redis runs in a separate "amonredis" core zone.
+groups, contacts) in [Moray](https://mo.joyent.com/docs/moray/master/)
+and shorter-lived data (alarms) in redis. Redis runs in a
+separate 'amonredis' core zone.
 
 There is an "Amon Relay" running on each compute node global zone to ferry
 (1) probe configuration down to Amon Agents where probes are run; and
 (2) events up from agents to the master for handling. This is installed with
-the agents shar (which includes all SDC agents) as "amon-relay" on each
+the agents shar (which includes all SDC agents) as 'amon-relay' on each
 compute node.
 
 There is an "Amon Agent" running at each location where the supported probes
-need to run. Currently that is each compute node global zone in the DC
+need to run. Currently that is each compute node global zone
 plus in each core SDC (and Manta) zone.
 
 
-# Code Layout
+## Code Layout
 
     master/         Amon master (node.js package)
     relay/          Amon relay (node.js package)
@@ -62,12 +63,11 @@ plus in each core SDC (and Manta) zone.
     tools/          General tools stuff for development of amon.
 
 
-
-# Development
+## Development
 
 Typically Amon development is done by:
 
-- making edits to a clone of sdc-amon.git on a Mac (likely Linux too, but that's
+1. Making edits to a clone of sdc-amon.git on a Mac (likely Linux too, but that's
   untested) or a SmartOS development zone,
 
         git clone git@github.com:joyent/sdc-amon.git
@@ -75,21 +75,20 @@ Typically Amon development is done by:
         git submodule update --init   # not necessary first time
         vi
 
-- building:
+1. Building:
 
         make all
         make check
 
-- syncing changes to a running SDC (typically a COAL running locally in VMWare)
+1. Syncing changes to a running SDC (typically CoaL running locally in VMware)
   via one or more of:
 
         ./tools/rsync-master-to-coal
         ./tools/rsync-relay-to-coal
         ./tools/rsync-agent-to-coal
 
-- then testing changes in that SDC (e.g. COAL).
+1. Testing changes in that SDC (e.g. CoaL).
   See "Testing" below for running the test suite.
-
 
 If you are developing from an OS other than SmartOS, you obviously can't be
 updating binary parts of Amon. Currently that typically only bites when trying
@@ -99,7 +98,7 @@ to update npm deps of the version of node used by the Amon components.
 ## Testing
 
 Currently the primary client of the test suite is testing *in a full
-install of all Amon components in a full SDC setup* (e.g. in COAL). The bulk of
+install of all Amon components in a full SDC setup* (e.g. in CoaL). The bulk of
 the test suite (everything under "test/...") is installed with the Amon Relay
 (i.e. in the headnode global zone).
 
@@ -112,13 +111,12 @@ This will run all the main tests against the running Amon system and also
 login to the Amon Master zone(s) and run its local test suite.
 
 
-To sync local changes to a running COAL and run the test suite there try:
+To sync local changes to a running CoaL and run the test suite there try:
 
     make test-coal
 
 
-
-# COAL Notes: Getting email notifications
+## CoaL Notes: Getting email notifications
 
 For many ISPs it is common for outbound SMTP traffic (port 25) to be blocked.
 This means that Amon Master's default mail config results in no outbound
@@ -138,9 +136,18 @@ this:
             "user": "YOUR-GMAIL-NAME@gmail.com",
             "pass": "YOUR-GMAIL-PASSWORD"
            },
-          "from": "\"Monitoring (no reply)\" <no-reply@joyent.com>"
+          "from": "\"Monitoring (no reply)\" <no-reply@example.com>"
         }
     $ svcadm restart amon-master
 
 Personally, I'm using a separate gmail account for this so I don't have
 to put my personal gmail password in that config file.
+
+
+## Dependencies
+registrar, restdown-brand-remora, node-sdc-clients, node-ufds,
+sdc-config-agent, sdc-scripts, sdcnode
+
+
+## License
+Amon is licensed under the [Mozilla Public License version 2.0](http://mozilla.org/MPL/2.0/).


### PR DESCRIPTION
* Project/product/trademark is just SmartDataCenter not Joyent SDC.
* Use single quotes for non-phrase 'output'.
* No user portal currently.
* rm "in the DC" otherwise more approp. on early "each compute node".
* Add Dependencies and License sections.