### PR TITLE
MANTA-4898 sdc-amon build fails on systems where default python is python3

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -349,6 +349,8 @@ install_relay_pkg:
 # Since modern pkgsrc installations have the default as python3, this
 # will break the build, so work around that. In cases where the default
 # is already python2, this is harmless.
+# This all occurs because amon uses an old node, which has an old version
+# of gyp. If we move to more modern node, we can probably drop this hack.
 #
 .PHONY: python2-symlink
 python2-symlink:

--- a/Makefile
+++ b/Makefile
@@ -83,9 +83,13 @@ TOP ?= $(error Unable to access eng.git submodule Makefiles.)
 # - Only make this PATH addition on SunOS where we know we have
 #   /opt/local/bin/gcc, otherwise other parts of the build using gcc on
 #   non-SunOS (e.g. 'make check' builds of jsl) break.
+# - ENGBLD_PATH is another route for us to add path components. In this
+#   case, allowing us to drop in a path containing a python2 -> python
+#   symlink, needed on systems where /opt/local/bin/python is python3,
+#   which would otherwise break node-gyp builds.
 #
 ifeq ($(shell uname -s),SunOS)
-	export PATH:=$(TOP)/tools/m32-gcc-wrapper:$(PATH)
+	export PATH:=$(TOP)/tools/m32-gcc-wrapper:$(ENGBLD_PATH):$(PATH)
 endif
 
 ifeq ($(shell uname -s),SunOS)


### PR DESCRIPTION
These are exactly the changes we've had running in the manta-rebalancer work. After this integrates, I'll modify the engbld branch of the rebalancer to switch to using the master branch agent build of sdc-amon again.